### PR TITLE
#20feat/sj/constraint embedding args

### DIFF
--- a/rl4co/configs/experiment/routing/am.yaml
+++ b/rl4co/configs/experiment/routing/am.yaml
@@ -26,12 +26,14 @@ model:
   val_data_size: 10_000
   test_data_size: 10_000
   optimizer_kwargs:
-    lr: 1e-4
+    lr: 1e-43
     weight_decay: 1e-6
   lr_scheduler: "MultiStepLR"
   lr_scheduler_kwargs:
     milestones: [80, 95]
     gamma: 0.1
+  policy_kwargs:
+    constraint_method: "weighted"
 
 trainer:
   max_epochs: 100

--- a/rl4co/configs/experiment/routing/am.yaml
+++ b/rl4co/configs/experiment/routing/am.yaml
@@ -16,7 +16,7 @@ logger:
     project: "rl4co"
     tags: ["am", "${env.name}"]
     group: ${env.name}${env.generator_params.num_loc}
-    name: am-${env.name}${env.generator_params.num_loc}
+    name: am-${env.name}${env.generator_params.num_loc}-${model.policy_kwargs.constraint_method}
 
 model:
   batch_size: 512

--- a/rl4co/configs/experiment/routing/am.yaml
+++ b/rl4co/configs/experiment/routing/am.yaml
@@ -26,7 +26,7 @@ model:
   val_data_size: 10_000
   test_data_size: 10_000
   optimizer_kwargs:
-    lr: 1e-43
+    lr: 1e-4
     weight_decay: 1e-6
   lr_scheduler: "MultiStepLR"
   lr_scheduler_kwargs:

--- a/rl4co/rl4co/envs/routing/cvrptw/env.py
+++ b/rl4co/rl4co/envs/routing/cvrptw/env.py
@@ -232,18 +232,18 @@ class CVRPTWEnv(CVRPEnv):
         type: str = None,
         compute_edge_weights: bool = False,
     ):
-        if solomon:
-            assert type in [
-                "instance",
-                "solution",
-            ], "type must be either 'instance' or 'solution'"
-            if type == "instance":
-                instance = load_solomon_instance(
-                    name=name, path=path_instances, edge_weights=compute_edge_weights
-                )
-            elif type == "solution":
-                instance = load_solomon_solution(name=name, path=path_instances)
-            return instance
+        # if solomon:
+        #     assert type in [
+        #         "instance",
+        #         "solution",
+        #     ], "type must be either 'instance' or 'solution'"
+        #     if type == "instance":
+        #         instance = load_solomon_instance(
+        #             name=name, path=path_instances, edge_weights=compute_edge_weights
+        #         )
+        #     elif type == "solution":
+        #         instance = load_solomon_solution(name=name, path=path_instances)
+        #     return instance
         return load_npz_to_tensordict(filename=name)
 
     def extract_from_solomon(self, instance: dict, batch_size: int = 1):

--- a/rl4co/rl4co/models/zoo/am/decoder.py
+++ b/rl4co/rl4co/models/zoo/am/decoder.py
@@ -77,6 +77,7 @@ class AttentionModelDecoder(AutoregressiveDecoder):
         out_bias_pointer_attn: bool = False,
         linear_bias: bool = False,
         use_graph_context: bool = True,
+        constraint_method: str = 'none',
         check_nan: bool = True,
         sdpa_fn: callable = None,
         pointer: nn.Module = None,
@@ -93,7 +94,13 @@ class AttentionModelDecoder(AutoregressiveDecoder):
         assert embed_dim % num_heads == 0
 
         self.context_embedding = (
-            env_context_embedding(self.env_name, {"embed_dim": embed_dim})
+            env_context_embedding(
+                self.env_name, 
+                {
+                    "embed_dim": embed_dim,
+                    "constraint_method": constraint_method
+                }
+            )
             if context_embedding is None
             else context_embedding
         )

--- a/rl4co/rl4co/models/zoo/am/policy.py
+++ b/rl4co/rl4co/models/zoo/am/policy.py
@@ -76,6 +76,7 @@ class AttentionModelPolicy(AutoregressivePolicy):
         val_decode_type: str = "greedy",
         test_decode_type: str = "greedy",
         moe_kwargs: dict = {"encoder": None, "decoder": None},
+        constraint_method: str = 'none',
         **unused_kwargs,
     ):
         if encoder is None:
@@ -106,6 +107,7 @@ class AttentionModelPolicy(AutoregressivePolicy):
                 use_graph_context=use_graph_context,
                 check_nan=check_nan,
                 moe_kwargs=moe_kwargs["decoder"],
+                constraint_method=constraint_method,
             )
 
         super(AttentionModelPolicy, self).__init__(


### PR DESCRIPTION
# Summary

- 제약조건 임베딩 방법론을 config로 설정할 수 있도록 수정하였습니다.
- weighted sum embedding을 구현하였습니다.

# Description

- configs/experiment/am.yaml 파일안에 constraint_method로 방법론을 설정할 수 있도록 하였습니다
- linear 방법론, 제약조건 임베딩x, weighted sum 방법론을 config로 수정 가능

> constraint_method에 따라 다른 제약조건 임베딩 
```python
class VRPContext(EnvContext):
    """Context embedding for the Capacitated Vehicle Routing Problem (CVRP)."""

    def __init__(self, embed_dim, constraint_method='none'):
        # Calculate step_context_dim based on constraint method
        if constraint_method == 'none':
            step_context_dim = embed_dim + 1
        elif constraint_method == 'linear':
            step_context_dim = 2 * embed_dim + 1  # original node embedding + capacity + contraint embedding
        elif constraint_method == 'weighted':
            step_context_dim = embed_dim + 3  # node embedding + capacity + constraint node weights mean

        super(VRPContext, self).__init__(
            embed_dim=embed_dim,
            step_context_dim=step_context_dim,
            num_reasons=2 if constraint_method != 'none' else None
        )

        self.constraint_method = constraint_method
        if constraint_method == 'weighted':
            self.node_weights = nn.Parameter(torch.ones(1))

    def _state_embedding(self, embeddings, td):
        # Get capacity state [batch_size, 1]
        state_embedding = td["vehicle_capacity"] - td["used_capacity"]

        if self.constraint_method == 'none':
            return state_embedding

        # Get constraint embedding [batch_size, num_loc, num_reasons]
        constraint_embedding = self.masking_encoder.onehot_encode(td["masking_reasons"])
        if constraint_embedding is None:
            raise ValueError("Constraint embedding is None but constraint_method is not 'none'. This might indicate an error in masking_reasons tensor.")

        if self.constraint_method == 'linear':
            # linear embedding method: linear projection and mean
            constraint_embedding = self.constraint_linear(constraint_embedding)
            constraint_embedding = constraint_embedding.mean(dim=1)

        elif self.constraint_method == 'weighted':
            # weighted method: weighted sum across nodes
            node_weights = self.node_weights.expand(
                constraint_embedding.size(0), 
                constraint_embedding.size(1), 
                1
            )
            constraint_embedding = (constraint_embedding * node_weights).sum(dim=1)


        return torch.cat([state_embedding, constraint_embedding], dim=-1)
``` 
- if문을 통해 구성

> state_embedding method안에 weighted sum embedding 방법론 구현
```python
        elif self.constraint_method == 'weighted':
            # weighted method: weighted sum across nodes
            node_weights = self.node_weights.expand(
                constraint_embedding.size(0), 
                constraint_embedding.size(1), 
                1
            )
            constraint_embedding = (constraint_embedding * node_weights).sum(dim=1)

``` 
- 제약조건 임베딩된 원핫 벡터들을 weighted sum 하여 하나의 벡터로 만들어 주는 방법

> 새로운 파라미터가 생김에 따라, arg 추가, path = model/am/decoder.py
```python
@dataclass
class PrecomputedCache:
    node_embeddings: Tensor
    graph_context: Union[Tensor, float]
    glimpse_key: Tensor
    glimpse_val: Tensor
    logit_key: Tensor

    @property
    def fields(self):
        return tuple(getattr(self, x.name) for x in fields(self))

    def batchify(self, num_starts):
        new_embs = []
        for emb in self.fields:
            if isinstance(emb, Tensor) or isinstance(emb, TensorDict):
                new_embs.append(batchify(emb, num_starts))
            else:
                new_embs.append(emb)
        return PrecomputedCache(*new_embs)


class AttentionModelDecoder(AutoregressiveDecoder):
    """
    Auto-regressive decoder based on Kool et al. (2019): https://arxiv.org/abs/1803.08475.
    Given the environment state and the embeddings, compute the logits and sample actions autoregressively until
    all the environments in the batch have reached a terminal state.
    In this case we additionally have a `pre_decoder_hook` method that allows to precompute the embeddings before
    the decoder is called, which saves a lot of computation.


    Args:
        embed_dim: Embedding dimension
        num_heads: Number of attention heads
        env_name: Name of the environment used to initialize embeddings
        context_embedding: Context embedding module
        dynamic_embedding: Dynamic embedding module
        mask_inner: Whether to mask the inner loop
        out_bias_pointer_attn: Whether to use a bias in the pointer attention
        linear_bias: Whether to use a bias in the linear layer
        use_graph_context: Whether to use the graph context
        check_nan: Whether to check for nan values during decoding
        sdpa_fn: scaled_dot_product_attention function
        pointer: Module implementing the pointer logic (defaults to PointerAttention)
        moe_kwargs: Keyword arguments for MoE
    """

    def __init__(
        self,
        embed_dim: int = 128,
        num_heads: int = 8,
        env_name: str = "CVRP",
        context_embedding: nn.Module = None,
        dynamic_embedding: nn.Module = None,
        mask_inner: bool = True,
        out_bias_pointer_attn: bool = False,
        linear_bias: bool = False,
        use_graph_context: bool = True,
        constraint_method: str = 'none',
        check_nan: bool = True,
        sdpa_fn: callable = None,
        pointer: nn.Module = None,
        moe_kwargs: dict = None,
    ):
``` 
> am모델의 policy.py arg에 contraint_method 추가
```python
class AttentionModelPolicy(AutoregressivePolicy):
    """
    Attention Model Policy based on Kool et al. (2019): https://arxiv.org/abs/1803.08475.
    This model first encodes the input graph using a Graph Attention Network (GAT) (:class:`AttentionModelEncoder`)
    and then decodes the solution using a pointer network (:class:`AttentionModelDecoder`). Cache is used to store the
    embeddings of the nodes to be used by the decoder to save computation.
    See :class:`rl4co.models.common.constructive.autoregressive.policy.AutoregressivePolicy` for more details on the inference process.

    Args:
        encoder: Encoder module, defaults to :class:`AttentionModelEncoder`
        decoder: Decoder module, defaults to :class:`AttentionModelDecoder`
        embed_dim: Dimension of the node embeddings
        num_encoder_layers: Number of layers in the encoder
        num_heads: Number of heads in the attention layers
        normalization: Normalization type in the attention layers
        feedforward_hidden: Dimension of the hidden layer in the feedforward network
        env_name: Name of the environment used to initialize embeddings
        encoder_network: Network to use for the encoder
        init_embedding: Module to use for the initialization of the embeddings
        context_embedding: Module to use for the context embedding
        dynamic_embedding: Module to use for the dynamic embedding
        use_graph_context: Whether to use the graph context
        linear_bias_decoder: Whether to use a bias in the linear layer of the decoder
        sdpa_fn_encoder: Function to use for the scaled dot product attention in the encoder
        sdpa_fn_decoder: Function to use for the scaled dot product attention in the decoder
        sdpa_fn: (deprecated) Function to use for the scaled dot product attention
        mask_inner: Whether to mask the inner product
        out_bias_pointer_attn: Whether to use a bias in the pointer attention
        check_nan: Whether to check for nan values during decoding
        temperature: Temperature for the softmax
        tanh_clipping: Tanh clipping value (see Bello et al., 2016)
        mask_logits: Whether to mask the logits during decoding
        train_decode_type: Type of decoding to use during training
        val_decode_type: Type of decoding to use during validation
        test_decode_type: Type of decoding to use during testing
        moe_kwargs: Keyword arguments for MoE,
            e.g., {"encoder": {"hidden_act": "ReLU", "num_experts": 4, "k": 2, "noisy_gating": True},
                   "decoder": {"light_version": True, ...}}
    """

    def __init__(
        self,
        encoder: nn.Module = None,
        decoder: nn.Module = None,
        embed_dim: int = 128,
        num_encoder_layers: int = 3,
        num_heads: int = 8,
        normalization: str = "batch",
        feedforward_hidden: int = 512,
        env_name: str = "tsp",
        encoder_network: nn.Module = None,
        init_embedding: nn.Module = None,
        context_embedding: nn.Module = None,
        dynamic_embedding: nn.Module = None,
        use_graph_context: bool = True,
        linear_bias_decoder: bool = False,
        sdpa_fn: Callable = None,
        sdpa_fn_encoder: Callable = None,
        sdpa_fn_decoder: Callable = None,
        mask_inner: bool = True,
        out_bias_pointer_attn: bool = False,
        check_nan: bool = True,
        temperature: float = 1.0,
        tanh_clipping: float = 10.0,
        mask_logits: bool = True,
        train_decode_type: str = "sampling",
        val_decode_type: str = "greedy",
        test_decode_type: str = "greedy",
        moe_kwargs: dict = {"encoder": None, "decoder": None},
        constraint_method: str = 'none',
        **unused_kwargs,
    ):
        if encoder is None:
            encoder = AttentionModelEncoder(
                embed_dim=embed_dim,
                num_heads=num_heads,
                num_layers=num_encoder_layers,
                env_name=env_name,
                normalization=normalization,
                feedforward_hidden=feedforward_hidden,
                net=encoder_network,
                init_embedding=init_embedding,
                sdpa_fn=sdpa_fn if sdpa_fn_encoder is None else sdpa_fn_encoder,
                moe_kwargs=moe_kwargs["encoder"],
            )

        if decoder is None:
            decoder = AttentionModelDecoder(
                embed_dim=embed_dim,
                num_heads=num_heads,
                env_name=env_name,
                context_embedding=context_embedding,
                dynamic_embedding=dynamic_embedding,
                sdpa_fn=sdpa_fn if sdpa_fn_decoder is None else sdpa_fn_decoder,
                mask_inner=mask_inner,
                out_bias_pointer_attn=out_bias_pointer_attn,
                linear_bias=linear_bias_decoder,
                use_graph_context=use_graph_context,
                check_nan=check_nan,
                moe_kwargs=moe_kwargs["decoder"],
                constraint_method=constraint_method,
            )

        super(AttentionModelPolicy, self).__init__(
            encoder=encoder,
            decoder=decoder,
            env_name=env_name,
            temperature=temperature,
            tanh_clipping=tanh_clipping,
            mask_logits=mask_logits,
            train_decode_type=train_decode_type,
            val_decode_type=val_decode_type,
            test_decode_type=test_decode_type,
            **unused_kwargs,
        )
``` 

> experiments/am.yaml에 constraint_method 추가
```shell
  val_data_size: 10_000
  test_data_size: 10_000
  optimizer_kwargs:
    lr: 1e-4
    weight_decay: 1e-6
  lr_scheduler: "MultiStepLR"
  lr_scheduler_kwargs:
    milestones: [80, 95]
    gamma: 0.1
  policy_kwargs:
    constraint_method: "weighted"

trainer:
  max_epochs: 100
``` 



---

- constraint_method에 따라 state_embedding이 다르게 되도록 설정하였고 config에서 해당 부분을 수정할 수 있도록 하였습니다.
- local상에서 cvrp 환경은 돌아가는데 문제가 없었으나, cvrptw 환경에서는 data_load에서 약간의 이슈가 있습니다.
  - data_load 안에서 vrplib이라는 곳에서 데이터를 다운 받아와서 tensordict으로 저장을 해주는데, 해당 부분에서 에러가 있습니다. 에러는 아래와 같습니다.
```powershell
    ext = "txt" if is_vrptw(name) else "vrp"
                   ^^^^^^^^^^^^^^
  File "/opt/homebrew/anaconda3/lib/python3.11/site-packages/vrplib/download/download_utils.py", line 43, in is_vrptw
    return find_set(name) in ["HG", "Solomon"]
           ^^^^^^^^^^^^^^
  File "/opt/homebrew/anaconda3/lib/python3.11/site-packages/vrplib/download/download_utils.py", line 35, in find_set
    raise ValueError(f"Set name not known for instance: {instance_name}.")
ValueError: Set name not known for instance: /Users/yunseongjun/Desktop/rl4co/data/cvrptw/cvrptw50_val_seed4321.npz.

Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace.
``` 
  - 일단은 학습 시킬 때는 데이터를 generate 하여 시키기 때문에, 다운을 받아오는 부분은 주석처리 하였습니다.
- constraint_method는 config에서 default로 weighted로 설정해놨습니다.
